### PR TITLE
Pass `rm` as self-removal function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -19,14 +19,20 @@ module.exports = function (filter) {
   }
 
   function many (ready, immediately) {
-    var i = listeners.push(ready) - 1
-    if(value !== null && immediately !== false) ready(value)
-    return function () { //manually remove...
+    function rm () { //manually remove...
       //fast path, will happen if an earlier listener has not been removed.
-      if(listeners[i] !== ready)
-        i = listeners.indexOf(ready)
+      if(listeners[i] !== boundReady)
+        i = listeners.indexOf(boundReady)
       listeners.splice(i, 1)
     }
+
+    const boundReady = ready.bind(rm)
+
+    var i = listeners.push(boundReady) - 1
+
+    if(value !== null && immediately !== false) boundReady(value)
+
+    return rm
   }
 
   many.set = function (_value) {

--- a/index.js
+++ b/index.js
@@ -2,10 +2,14 @@
 module.exports = function (filter) {
   var value = null, listeners = [], oncers = []
   function trigger (_value) {
+    function rm () { //manually remove...
+      listeners.splice(i, 1)
+    }
+
     value = _value
     var length = listeners.length
     for(var i = 0; i< length && value === _value; i++) {
-      var listener = listeners[i](value)
+      listeners[i](value, rm)
       //if we remove a listener, must decrement i also
     }
     // decrement from length, incase a !immediately
@@ -21,16 +25,14 @@ module.exports = function (filter) {
   function many (ready, immediately) {
     function rm () { //manually remove...
       //fast path, will happen if an earlier listener has not been removed.
-      if(listeners[i] !== boundReady)
-        i = listeners.indexOf(boundReady)
+      if(listeners[i] !== ready)
+        i = listeners.indexOf(ready)
       listeners.splice(i, 1)
     }
 
-    const boundReady = ready.bind(rm)
+    var i = listeners.push(ready) - 1
 
-    var i = listeners.push(boundReady) - 1
-
-    if(value !== null && immediately !== false) boundReady(value)
+    if(value !== null && immediately !== false) ready(value, rm)
 
     return rm
   }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,18 @@
 
 module.exports = function (filter) {
   var value = null, listeners = [], oncers = []
+
   function trigger (_value) {
-    function rm () { //manually remove...
-      listeners.splice(i, 1)
-    }
+    const isUnchanged = () => value === _value
+    const rm = () => listeners[i] = null
 
     value = _value
     var length = listeners.length
-    for(var i = 0; i< length && value === _value; i++) {
-      listeners[i](value, rm)
+    for(var i = 0; i< length && isUnchanged(); i++) {
+      const ready = listeners[i]
+      if (typeof ready === 'function') {
+        ready(value, rm)
+      }
       //if we remove a listener, must decrement i also
     }
     // decrement from length, incase a !immediately
@@ -17,7 +20,7 @@ module.exports = function (filter) {
     var l = oncers.length
     var _oncers = oncers
     oncers = []
-    while(l-- && _value === value) {
+    while(l-- && isUnchanged()) {
       _oncers.shift()(value)
     }
   }
@@ -25,9 +28,10 @@ module.exports = function (filter) {
   function many (ready, immediately) {
     function rm () { //manually remove...
       //fast path, will happen if an earlier listener has not been removed.
-      if(listeners[i] !== ready)
+      if(listeners[i] !== ready) {
         i = listeners.indexOf(ready)
-      listeners.splice(i, 1)
+      }
+      listeners[i] = null
     }
 
     var i = listeners.push(ready) - 1

--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
-
 module.exports = function (filter) {
   var value = null, listeners = [], oncers = []
 
   function trigger (_value) {
     const isUnchanged = () => value === _value
-    const rm = () => listeners[i] = null
+    const rm = () => listeners.splice(i, 1)
+    const listenersClone = [...listeners]
 
     value = _value
-    var length = listeners.length
+    var length = listenersClone.length
+
     for(var i = 0; i< length && isUnchanged(); i++) {
-      const ready = listeners[i]
+      const ready = listenersClone[i]
       if (typeof ready === 'function') {
         ready(value, rm)
       }
@@ -31,7 +32,7 @@ module.exports = function (filter) {
       if(listeners[i] !== ready) {
         i = listeners.indexOf(ready)
       }
-      listeners[i] = null
+      listeners.splice(i, 1)
     }
 
     var i = listeners.push(ready) - 1

--- a/test/trigger.js
+++ b/test/trigger.js
@@ -58,40 +58,64 @@ module.exports = function (observable) {
   })
 
   tape('remove self from inside listener', function (t) {
-    var o = observable()
-    var value = Math.random(), checked = 0
+    const o = observable()
+    const value = Math.random()
+    let firstCalled = 0
+    let secondCalled = 0
 
     o.set(value)
 
-    o(function (_value) {
+    o(function (_value, rm) {
       t.equal(_value, value)
-      checked ++
-      this()
+      firstCalled += 1
+      rm()
     })
 
-    t.equal(checked, 1)
+    o(function (_value, rm) {
+      t.equal(_value, value)
+      secondCalled += 1
+      rm()
+    })
+
+    t.equal(firstCalled, 1)
+    t.equal(secondCalled, 1)
+
     o.set(value)
-    t.equal(checked, 1)
+
+    t.equal(firstCalled, 1)
+    t.equal(secondCalled, 1)
+
     t.end()
   })
 
   tape('remove self from inside listener, not immediate', function (t) {
-    var o = observable()
-    var value = Math.random(), checked = 0
+    const o = observable()
+    const value = Math.random()
+    let firstCalled = 0
+    let secondCalled = 0
 
     o.set(value)
 
-    o(function (_value) {
+    o(function (_value, rm) {
       t.equal(_value, value)
-      checked ++
-      this()
+      firstCalled += 1
+      rm()
     }, false)
 
-    t.equal(checked, 0)
+    o(function (_value, rm) {
+      t.equal(_value, value)
+      secondCalled += 1
+      rm()
+    })
+
+    t.equal(firstCalled, 0)
+    t.equal(secondCalled, 1)
+
     o.set(value)
-    t.equal(checked, 1)
-    o.set(value)
-    t.equal(checked, 1)
+
+    t.equal(firstCalled, 1)
+    t.equal(secondCalled, 1)
+
     t.end()
   })
 

--- a/test/trigger.js
+++ b/test/trigger.js
@@ -88,6 +88,37 @@ module.exports = function (observable) {
     t.end()
   })
 
+  tape('remove self, keep a second listener', function (t) {
+    const o = observable()
+    const value = Math.random()
+    let firstCalled = 0
+    let secondCalled = 0
+
+    o.set(value)
+
+    o(function (_value, rm) {
+      t.equal(_value, value)
+      firstCalled += 1
+      rm()
+    })
+
+    o(function (_value, rm) {
+      t.equal(_value, value)
+      secondCalled += 1
+    })
+
+    t.equal(firstCalled, 1)
+    t.equal(secondCalled, 1)
+
+    o.set(value)
+
+    t.equal(firstCalled, 1)
+    t.equal(secondCalled, 2)
+
+    t.end()
+  })
+
+
   tape('remove self from inside listener, not immediate', function (t) {
     const o = observable()
     const value = Math.random()
@@ -105,7 +136,7 @@ module.exports = function (observable) {
     o(function (_value, rm) {
       t.equal(_value, value)
       secondCalled += 1
-      rm()
+      //rm()
     })
 
     t.equal(firstCalled, 0)
@@ -118,6 +149,40 @@ module.exports = function (observable) {
 
     t.end()
   })
+
+
+  tape('remove self from inside listener, not immediate, keep second listener', function (t) {
+    const o = observable()
+    const value = Math.random()
+    let firstCalled = 0
+    let secondCalled = 0
+
+    o.set(value)
+
+    //not called immediately, but called from next o.set(value)
+    o(function (_value, rm) {
+      t.equal(_value, value)
+      firstCalled += 1
+      rm()
+    }, false)
+
+    o(function (_value, rm) {
+      t.equal(_value, value)
+      secondCalled += 1
+    })
+
+    //set (fn, false)
+    t.equal(firstCalled, 0)
+    t.equal(secondCalled, 1)
+
+    o.set(value)
+
+    t.equal(firstCalled, 1)
+    t.equal(secondCalled, 2)
+
+    t.end()
+  })
+
 
   tape('add listener within trigger', function (t) {
     var o = observable()
@@ -228,4 +293,7 @@ module.exports = function (observable) {
 }
 
 if(!module.parent) module.exports (require('../'))
+
+
+
 

--- a/test/trigger.js
+++ b/test/trigger.js
@@ -57,6 +57,44 @@ module.exports = function (observable) {
 
   })
 
+  tape('remove self from inside listener', function (t) {
+    var o = observable()
+    var value = Math.random(), checked = 0
+
+    o.set(value)
+
+    o(function (_value) {
+      t.equal(_value, value)
+      checked ++
+      this()
+    })
+
+    t.equal(checked, 1)
+    o.set(value)
+    t.equal(checked, 1)
+    t.end()
+  })
+
+  tape('remove self from inside listener, not immediate', function (t) {
+    var o = observable()
+    var value = Math.random(), checked = 0
+
+    o.set(value)
+
+    o(function (_value) {
+      t.equal(_value, value)
+      checked ++
+      this()
+    }, false)
+
+    t.equal(checked, 0)
+    o.set(value)
+    t.equal(checked, 1)
+    o.set(value)
+    t.equal(checked, 1)
+    t.end()
+  })
+
   tape('add listener within trigger', function (t) {
     var o = observable()
 

--- a/test/trigger.js
+++ b/test/trigger.js
@@ -136,7 +136,7 @@ module.exports = function (observable) {
     o(function (_value, rm) {
       t.equal(_value, value)
       secondCalled += 1
-      //rm()
+      rm()
     })
 
     t.equal(firstCalled, 0)
@@ -171,7 +171,6 @@ module.exports = function (observable) {
       secondCalled += 1
     })
 
-    //set (fn, false)
     t.equal(firstCalled, 0)
     t.equal(secondCalled, 1)
 
@@ -230,8 +229,6 @@ module.exports = function (observable) {
       if(last2) t.ok(v > last2, 'monotonic increasing listeners')
       last2 = v
     })
-
-
 
     o.set(checked)
 
@@ -293,7 +290,4 @@ module.exports = function (observable) {
 }
 
 if(!module.parent) module.exports (require('../'))
-
-
-
 


### PR DESCRIPTION
This binds the `ready()` function so that `this()` actually runs `rm()` on itself, that way listeners have a way to remove themselves without any JavaScript gymnastics. This is technically a breaking change because we're changing `this`, so maybe if/when this is merged we could release as obv@1.0.0?

## Before

```js
var rm = sv.since(function (v) {
  if(v === log.since.value) {
    var _cb = cb; cb = null; _cb()
  }
  if(!cb && rm) rm()
})
```

## After

```js
sv.since(function (v) {
  if(v === log.since.value) {
    var _cb = cb; cb = null; _cb()
    this()
  }
})
```

---

Edited the above examples because the original had slightly different behavior as it didn't protect against the double-`cb()` race condition.